### PR TITLE
Time for merged tracksters

### DIFF
--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
@@ -7,7 +7,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "PatternRecognitionbyCA.h"
-#include "RecoLocalCalo/HGCalRecProducers/interface/ComputeClusterTime.h"
 
 #include "TrackstersPCA.h"
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
@@ -117,32 +116,13 @@ void PatternRecognitionbyCA<TILES>::makeTracksters(
     tracksterId++;
 
     std::set<unsigned int> effective_cluster_idx;
-    std::pair<std::set<unsigned int>::iterator, bool> retVal;
-
-    std::vector<float> times;
-    std::vector<float> timeErrors;
 
     for (auto const &doublet : ntuplet) {
       auto innerCluster = doublets[doublet].innerClusterId();
       auto outerCluster = doublets[doublet].outerClusterId();
 
-      retVal = effective_cluster_idx.insert(innerCluster);
-      if (retVal.second) {
-        float time = input.layerClustersTime.get(innerCluster).first;
-        if (time > -99) {
-          times.push_back(time);
-          timeErrors.push_back(1. / pow(input.layerClustersTime.get(innerCluster).second, 2));
-        }
-      }
-
-      retVal = effective_cluster_idx.insert(outerCluster);
-      if (retVal.second) {
-        float time = input.layerClustersTime.get(outerCluster).first;
-        if (time > -99) {
-          times.push_back(time);
-          timeErrors.push_back(1. / pow(input.layerClustersTime.get(outerCluster).second, 2));
-        }
-      }
+      effective_cluster_idx.insert(innerCluster);
+      effective_cluster_idx.insert(outerCluster);
 
       if (PatternRecognitionAlgoBaseT<TILES>::algo_verbosity_ > PatternRecognitionAlgoBaseT<TILES>::Advanced) {
         LogDebug("HGCPatternRecoByCA") << " New doublet " << doublet << " for trackster: " << result.size()
@@ -210,7 +190,7 @@ void PatternRecognitionbyCA<TILES>::makeTracksters(
     }
   }
   ticl::assignPCAtoTracksters(
-      tmpTracksters, input.layerClusters, rhtools_.getPositionLayer(rhtools_.lastLayerEE(type)).z());
+			      tmpTracksters, input.layerClusters, input.layerClustersTime, rhtools_.getPositionLayer(rhtools_.lastLayerEE(type)).z());
 
   // run energy regression and ID
   energyRegressionAndID(input.layerClusters, tmpTracksters);
@@ -268,7 +248,8 @@ void PatternRecognitionbyCA<TILES>::makeTracksters(
     tmp.swap(result);
   }
 
-  ticl::assignPCAtoTracksters(result, input.layerClusters, rhtools_.getPositionLayer(rhtools_.lastLayerEE(type)).z());
+  ticl::assignPCAtoTracksters(result, input.layerClusters, input.layerClustersTime, rhtools_.getPositionLayer(rhtools_.lastLayerEE(type)).z());
+
   // run energy regression and ID
   energyRegressionAndID(input.layerClusters, result);
 

--- a/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
+++ b/RecoHGCal/TICL/plugins/PatternRecognitionbyCA.cc
@@ -181,10 +181,6 @@ void PatternRecognitionbyCA<TILES>::makeTracksters(
       //if a seeding region does not lead to any trackster
       tmp.setSeed(input.regions[0].collectionID, seedIndices[tracksterId]);
 
-      std::pair<float, float> timeTrackster(-99., -1.);
-      hgcalsimclustertime::ComputeClusterTime timeEstimator;
-      timeTrackster = timeEstimator.fixSizeHighestDensity(times, timeErrors);
-      tmp.setTimeAndError(timeTrackster.first, timeTrackster.second);
       std::copy(std::begin(effective_cluster_idx), std::end(effective_cluster_idx), std::back_inserter(tmp.vertices()));
       tmpTracksters.push_back(tmp);
     }

--- a/RecoHGCal/TICL/plugins/TrackstersPCA.cc
+++ b/RecoHGCal/TICL/plugins/TrackstersPCA.cc
@@ -9,6 +9,7 @@
 
 void ticl::assignPCAtoTracksters(std::vector<Trackster> &tracksters,
                                  const std::vector<reco::CaloCluster> &layerClusters,
+				 const edm::ValueMap<std::pair<float, float>> &layerClustersTime,
                                  double z_limit_em,
                                  bool energyWeight) {
   LogDebug("TrackstersPCA_Eigen") << "------- Eigen -------" << std::endl;
@@ -40,6 +41,9 @@ void ticl::assignPCAtoTracksters(std::vector<Trackster> &tracksters,
     sigmasEigen << 0., 0., 0.;
     Eigen::Matrix3d covM = Eigen::Matrix3d::Zero();
 
+    std::vector<float> times;
+    std::vector<float> timeErrors;
+
     for (size_t i = 0; i < N; ++i) {
       auto fraction = 1.f / trackster.vertex_multiplicity(i);
       trackster.addToRawEnergy(layerClusters[trackster.vertices(i)].energy() * fraction);
@@ -52,9 +56,20 @@ void ticl::assignPCAtoTracksters(std::vector<Trackster> &tracksters,
       fillPoint(layerClusters[trackster.vertices(i)], weight);
       for (size_t j = 0; j < 3; ++j)
         barycenter[j] += point[j];
+
+      // Also compute timing
+      float timeE = layerClustersTime.get(trackster.vertices(i)).second;
+      if (timeE > -1.) {
+	times.push_back(layerClustersTime.get(trackster.vertices(i)).first);
+	timeErrors.push_back(1. / pow(timeE, 2));
+      }
     }
     if (energyWeight && trackster.raw_energy())
       barycenter /= trackster.raw_energy();
+
+    std::pair<float, float> timeTrackster(-99., -1.);
+    hgcalsimclustertime::ComputeClusterTime timeEstimator;
+    timeTrackster = timeEstimator.fixSizeHighestDensity(times, timeErrors);
 
     // Compute the Covariance Matrix and the sum of the squared weights, used
     // to compute the correct normalization.
@@ -100,6 +115,7 @@ void ticl::assignPCAtoTracksters(std::vector<Trackster> &tracksters,
 
     // Add trackster attributes
     trackster.setBarycenter(ticl::Trackster::Vector(barycenter));
+    trackster.setTimeAndError(timeTrackster.first, timeTrackster.second);
     trackster.fillPCAVariables(
         eigenvalues_fromEigen, eigenvectors_fromEigen, sigmas, sigmasEigen, 3, ticl::Trackster::PCAOrdering::ascending);
 
@@ -110,6 +126,7 @@ void ticl::assignPCAtoTracksters(std::vector<Trackster> &tracksters,
     LogDebug("TrackstersPCA") << "raw_pt: " << trackster.raw_pt() << std::endl;
     LogDebug("TrackstersPCA") << "Means:          " << barycenter[0] << ", " << barycenter[1] << ", " << barycenter[2]
                               << std::endl;
+    LogDebug("TrackstersPCA") << "Time:          " << trackster.time() << " +/- " << trackster.timeError() << std::endl;
     LogDebug("TrackstersPCA") << "EigenValues from Eigen/Tr(cov): " << eigenvalues_fromEigen[2] / covM.trace() << ", "
                               << eigenvalues_fromEigen[1] / covM.trace() << ", "
                               << eigenvalues_fromEigen[0] / covM.trace() << std::endl;

--- a/RecoHGCal/TICL/plugins/TrackstersPCA.h
+++ b/RecoHGCal/TICL/plugins/TrackstersPCA.h
@@ -3,12 +3,14 @@
 
 #include "DataFormats/HGCalReco/interface/Trackster.h"
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
-
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "RecoLocalCalo/HGCalRecProducers/interface/ComputeClusterTime.h"
 #include <vector>
 
 namespace ticl {
   void assignPCAtoTracksters(std::vector<Trackster> &,
                              const std::vector<reco::CaloCluster> &,
+			     const edm::ValueMap<std::pair<float, float>> &,
                              double,
                              bool energyWeight = true);
 }


### PR DESCRIPTION
This PR
* Moves the timing computation in "assignPCAtoTracksters" where position and energy are recomputed looking at all the layer clusters in a given trackster
* This naturally extends the timing computation to the merged tracksters
* The timing is computed as usual, from the time and errors of all the layer clusters in the considered trackster (each counted only once)